### PR TITLE
Fixed times bug and small refactor

### DIFF
--- a/LoopTags.php
+++ b/LoopTags.php
@@ -22,7 +22,7 @@ class LoopTags extends Tags
 
         // Loop by times
         if ($times) {
-            for ($i = $from; $i <= $end; $i++) {
+            for ($i = 0; $i < $times; $i++) {
                 $vars[] = array(
                     'value' => $i
                 );

--- a/LoopTags.php
+++ b/LoopTags.php
@@ -17,7 +17,6 @@ class LoopTags extends Tags
         $from    = $this->getInt('from', 1);
         $to      = $this->getInt('to', null);
         $times   = $this->getInt('times', null);
-        $end     = $end = ($times) ? ($from + $times) : $to;
         $vars    = [];
 
         // Loop by times
@@ -31,7 +30,7 @@ class LoopTags extends Tags
 
         // Loop by from - to ascending
         if ($to && $from < $to) {
-            for ($i = $from; $i <= $end; $i++) {
+            for ($i = $from; $i <= $to; $i++) {
                 $vars[] = array(
                     'value' => $i
                 );
@@ -40,7 +39,7 @@ class LoopTags extends Tags
 
         // Loop by from - to descending
         if ($to && $from > $to) {
-            for ($i = $from; $i >= $end; $i--) {
+            for ($i = $from; $i >= $to; $i--) {
                 $vars[] = array(
                     'value' => $i
                 );


### PR DESCRIPTION
Not sure if you'll be interested in these changes but I noticed a bug where if `1` was passed into `times`, nothing would get rendered.

Additionally, when using `times` I expect `to` & `from` to be ignored completely since I want to loop an exact number of times. With this change, the `$end` variable was no longer needed, so I cleaned up the code a bit.